### PR TITLE
refactor: update Farinel class and Jest configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,12 +4,6 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testTimeout: 999999,
   verbose: true,
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.json',
-      sourceMap: true
-    }
-  },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "farinel",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A clever and mischievous framework that makes your code dance with joy! As cunning as it is lightweight - because being smart doesn't mean being heavy!",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",

--- a/src/__tests__/farinel-html.test.ts
+++ b/src/__tests__/farinel-html.test.ts
@@ -47,7 +47,7 @@ describe('Farinel with HTML elements', () => {
             Div({}, `counter: ${farinelInstance.state.counter}`),
             Button({}, "Increment")
               .on("click", async () => {
-                await farinelInstance.setState({
+                await farinelInstance.dispatch({
                   ...farinelInstance.state,
                   counter: farinelInstance.state.counter + 1
                 });
@@ -116,7 +116,7 @@ describe('Farinel with HTML elements', () => {
             }, `Option ${i}`))
           )
             .on("change", async (e: any) => {
-              await farinelInstance.setState({
+              await farinelInstance.dispatch({
                 value: Number(e.target.value)
               });
             })
@@ -183,7 +183,7 @@ describe('Farinel with HTML elements', () => {
             value: farinelInstance.state.value
           })
             .on("input", async (e: any) => {
-              await farinelInstance.setState({
+              await farinelInstance.dispatch({
                 value: e.target.value
               });
             })
@@ -213,7 +213,7 @@ describe('Farinel with HTML elements', () => {
         .otherwise(() => 
           Button({}, 'Login')
             .on("click", async () => {
-              await farinelInstance.setState({
+              await farinelInstance.dispatch({
                 logged: true
               });
             })
@@ -261,11 +261,11 @@ describe('Farinel with HTML elements', () => {
           .otherwise(() =>
             Button({}, text)
               .on("click", async () => {
-                await button.setState({
+                await button.dispatch({
                   login: true
                 });
 
-                await farinelInstance.setState({
+                await farinelInstance.dispatch({
                   logged: true
                 });
               })
@@ -326,11 +326,11 @@ describe('Farinel with HTML elements', () => {
             Div({},
               Button({}, text)
                 .on("click", async () => {
-                  await button.setState({
+                  await button.dispatch({
                     login: true
                   });
 
-                  await farinelInstance.setState({
+                  await farinelInstance.dispatch({
                     logged: true
                   });
                 })
@@ -405,13 +405,13 @@ describe('Farinel with HTML elements', () => {
               ),
               Button({}, text)
                 .on("click", async () => {
-                  await form.setState({
+                  await form.dispatch({
                     loading: true
                   });
                   
                   await new Promise(resolve => setTimeout(resolve, 100));
 
-                  await farinelInstance.setState({
+                  await farinelInstance.dispatch({
                     logged: true
                   });
                 })
@@ -484,11 +484,6 @@ describe('Farinel with HTML elements', () => {
       }: {
         onLogin: (email: string, password: string) => void
       }) => {
-        const formData = {
-          email: '',
-          password: ''
-        }
-
         const loginPage = farinel()
         .stating(() => ({
           loading: false,
@@ -496,18 +491,19 @@ describe('Farinel with HTML elements', () => {
         .otherwise(() =>
           Div({},
             Input({ type: 'email' })
-              .on("input", (e: any) => formData.email = e.target.value),
+              .on("input", (e: any) => loginPage.state.email = e.target.value),
             Input({ type: 'password' })
-              .on("input", (e: any) => formData.password = e.target.value),
+              .on("input", (e: any) => loginPage.state.password = e.target.value),
             Button({
               disabled: loginPage.state.loading
             }, "Login")
               .on("click", async () => {
-                await loginPage.setState({
+                await loginPage.dispatch({
+                  ...loginPage.state,
                   loading: true
                 });
 
-                await onLogin(formData.email, formData.password);
+                await onLogin(loginPage.state.email, loginPage.state.password);
               })
           )
         );
@@ -540,11 +536,11 @@ describe('Farinel with HTML elements', () => {
       const onLogin = async (email: string, password: string) => {
         const { user } = await mockApi.auth.login(email, password);
 
-        await farinelInstance.setState({ isAuthenticated: true, user });
+        await farinelInstance.dispatch({ isAuthenticated: true, user });
       }
       
       const onLogout = async () => {
-        await farinelInstance.setState({ isAuthenticated: false, user: null });
+        await farinelInstance.dispatch({ isAuthenticated: false, user: null });
       }
 
       const loginPage = LoginPage({ onLogin });
@@ -585,6 +581,9 @@ describe('Farinel with HTML elements', () => {
       loginButton.click();
 
       await loginPageUpdateState;
+
+      expect(loginPage.state.email).toEqual('test@example.com');
+      expect(loginPage.state.password).toEqual('password123');
 
       expect(domContainer.querySelector('button')?.disabled).toBe(true);
 

--- a/src/farinel.ts
+++ b/src/farinel.ts
@@ -17,14 +17,6 @@ export class Farinel {
     return this._matcher.context.value;
   }
 
-  get farinelContainer(): Farinel | null {
-    return this._farinelContainer;
-  }
-
-  set farinelContainer(farinel: Farinel) {
-    this._farinelContainer = farinel;
-  }
-
   async createRoot(container: HTMLElement, farinel: Farinel) {
     const element = await farinel.resolve();
 
@@ -35,7 +27,15 @@ export class Farinel {
     return this;
   }
 
+  /**
+   * @deprecated This method is deprecated and will be removed in a future release.  
+   * Please use {@link dispatch} instead.  
+   */
   async setState(newState: any) {
+    await this.dispatch(newState);
+  }
+
+  async dispatch(newState: any) {
     if (!this._matcher.context.returnValue) {
       throw new Error("Element not found");
     }
@@ -151,6 +151,14 @@ export class Farinel {
     this._matcher.return();
 
     return this;
+  }
+
+  private get farinelContainer(): Farinel | null {
+    return this._farinelContainer;
+  }
+
+  private set farinelContainer(farinel: Farinel) {
+    this._farinelContainer = farinel;
   }
 
   private updateContainer(returnValue: Element) {

--- a/src/html/index.ts
+++ b/src/html/index.ts
@@ -1,5 +1,7 @@
 import { Element } from './element';
 
+export { Element };
+
 // Basic elements
 export const A = (attributes: any, ...children: any[]) => new Element("a", attributes, ...children);
 export const B = (attributes: any, ...children: any[]) => new Element("b", attributes, ...children);


### PR DESCRIPTION
- Remove deprecated getter and setter for farinelContainer in the Farinel class
- Replace setState method with dispatch method for state updates
- Clean up Jest configuration by removing unused globals
- Update tests to use dispatch method for state management